### PR TITLE
[EKA-1] Introducting transaction id for discovery and link

### DIFF
--- a/hip-service/wwwroot/swagger.yaml
+++ b/hip-service/wwwroot/swagger.yaml
@@ -219,6 +219,9 @@ components:
     PatientDiscoveryRequest:
       type: object
       properties:
+        transactionId:
+          type: object
+          format: uuid
         patient:
           type: object
           properties:
@@ -279,6 +282,9 @@ components:
     PatientDiscoveryResponse:
       type: object
       properties:
+        transactionId:
+          type: string
+          format: uuid
         patient:
           $ref: '#/components/schemas/PatientRepresentation'
       xml:
@@ -326,19 +332,25 @@ components:
     PatientLinkReferenceRequest:
       type: object
       properties:
-        careManagerUserID:
+        transactionId:
           type: string
-        patientReferenceNumber:
-          type: string
-        careContexts:
-          type: array
-          items:
-            $ref: '#/components/schemas/CareContext'
+          format: uuid
+        link:
+          type:object
+          properties:
+            careManagerUserID:
+              type: string
+            patientReferenceNumber:
+              type: string
+            careContexts:
+              type: array
+              items:
+                $ref: '#/components/schemas/CareContext'
+              xml:
+                name: careContexts
+                wrapped: true
           xml:
-            name: careContexts
-            wrapped: true
-      xml:
-        name: PatientLinkReferenceRequest
+            name: PatientLinkReferenceRequest
 
     PatientLinkRequest:
       type: object


### PR DESCRIPTION
Introduced transactionID in the discovery and link which will be used to verify in the link request there was a discovery request against this transactionID earlier.