### PR TITLE
rename-request-id | Fixes a bug on hip-service where the transaction …

### DIFF
--- a/src/In.ProjectEKA.HipService/DataFlow/DataRequest.cs
+++ b/src/In.ProjectEKA.HipService/DataFlow/DataRequest.cs
@@ -9,7 +9,7 @@ namespace In.ProjectEKA.HipService.DataFlow
         public DateRange DateRange { get; }
         public string DataPushUrl { get; }
         public IEnumerable<HiType> HiType { get; }
-        public string RequestId { get; }
+        public string TransactionId { get; }
         public KeyMaterial KeyMaterial { get; }
         public string ConsentManagerId { get; }
         public string ConsentId { get; }
@@ -27,7 +27,7 @@ namespace In.ProjectEKA.HipService.DataFlow
             DateRange = dateRange;
             DataPushUrl = dataPushUrl;
             HiType = hiType;
-            RequestId = transactionId;
+            TransactionId = transactionId;
             KeyMaterial = keyMaterial;
             ConsentManagerId = consentManagerId;
             ConsentId = consentId;


### PR DESCRIPTION
…id is renamed as request id

* Since the transaction id was renamed to request id, health-information request was having the transaction id as null and the data flow was not getting completed