### PR TITLE
Fix version conflicts caused by PR#507

### DIFF
--- a/src/In.ProjectEKA.DefaultHip/In.ProjectEKA.DefaultHip.csproj
+++ b/src/In.ProjectEKA.DefaultHip/In.ProjectEKA.DefaultHip.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/In.ProjectEKA.HipService/In.ProjectEKA.HipService.csproj
+++ b/src/In.ProjectEKA.HipService/In.ProjectEKA.HipService.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>In.ProjectEKA.HipService</RootNamespace>
     <LangVersion>latest</LangVersion>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
@@ -35,7 +35,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.ReDoc" Version="5.5.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="5.5.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.5.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.8" />
     <PackageReference Include="HangFire" Version="1.7.12" />
     <PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
   </ItemGroup>

--- a/test/In.ProjectEKA.DefaultHipTest/In.ProjectEKA.DefaultHipTest.csproj
+++ b/test/In.ProjectEKA.DefaultHipTest/In.ProjectEKA.DefaultHipTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/In.ProjectEKA.HipServiceTest/In.ProjectEKA.HipServiceTest.csproj
+++ b/test/In.ProjectEKA.HipServiceTest/In.ProjectEKA.HipServiceTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <RootNamespace>In.ProjectEKA.HipServiceTest</RootNamespace>
         <LangVersion>8</LangVersion>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Microsoft.AspNetCore.Authentication.JwtBearer from 3.1.6 to 5.0.8. [(PR#507)](https://github.com/ProjectEKA/hip-service/pull/507).
Hope this fix can help you.

Best regards,
sucrose